### PR TITLE
get sample from ambient sound

### DIFF
--- a/scripting/SoundManager.sp
+++ b/scripting/SoundManager.sp
@@ -187,6 +187,18 @@ public Action OnPlayerRunCmd(int client)
 		{
 			char sSound[PLATFORM_MAX_PATH];
 			GetEntPropString(entity, Prop_Data, "m_iszSound", sSound, PLATFORM_MAX_PATH);
+
+			int channel = SNDCHAN_STATIC;
+			int level = SNDLEVEL_NONE;
+			float volume = 0.0;
+			int pitch = SNDPITCH_NORMAL;
+			char sSample[PLATFORM_MAX_PATH];
+
+			if (GetGameSoundParams(sSound, channel, level, volume, pitch, sSample, sizeof(sSample), entity))
+			{
+				sSound = sSample;
+			}
+
 			EmitSoundToClient(client, sSound, entity, SNDCHAN_STATIC, SNDLEVEL_NONE, SND_STOP, 0.0, SNDPITCH_NORMAL, _, _, _, true);
 
 			if(gI_Settings[client] & Debug)


### PR DESCRIPTION
On `bhop_bathhouse`, there are `ambient_generic` with `water_flood_finished_loop` as the sound. Trying to emit this to the client doesn't work for whatever reason so the sound doesn't stop.
This grabs the actual sample (`ambient/water/water_flow_loop1.wav`) which works for emitting to stop the sound.
The variables probably don't need to be initialized since they are probably replaced by `GetGameSoundParams` since they're references, but it's probably fine.

Also just some notes for me so I can reuse them whenever I remember this `sv_soundemitter_trace 1`, `snd_dumpclientsounds`, `snd_show 1`